### PR TITLE
Introduce core starter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
 		<module>spring-modulith-docs</module>
 		<module>spring-modulith-observability</module>
 		<module>spring-modulith-moments</module>
+		<module>spring-modulith-starter</module>
 		<module>spring-modulith-starter-jdbc</module>
 		<module>spring-modulith-starter-jpa</module>
 		<module>spring-modulith-starter-mongodb</module>

--- a/spring-modulith-starter-jdbc/pom.xml
+++ b/spring-modulith-starter-jdbc/pom.xml
@@ -19,27 +19,8 @@
 
 		<dependency>
 			<groupId>org.springframework.experimental</groupId>
-			<artifactId>spring-modulith-api</artifactId>
+			<artifactId>spring-modulith-starter</artifactId>
 			<version>0.1.0-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.experimental</groupId>
-			<artifactId>spring-modulith-moments</artifactId>
-			<version>0.1.0-SNAPSHOT</version>
-		</dependency>
-
-		<!-- Events -->
-
-		<dependency>
-			<groupId>org.springframework.experimental</groupId>
-			<artifactId>spring-modulith-events-core</artifactId>
-			<version>0.1.0-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.experimental</groupId>
-			<artifactId>spring-modulith-events-jackson</artifactId>
-			<version>0.1.0-SNAPSHOT</version>
-			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.experimental</groupId>

--- a/spring-modulith-starter-mongodb/pom.xml
+++ b/spring-modulith-starter-mongodb/pom.xml
@@ -19,27 +19,8 @@
 
 		<dependency>
 			<groupId>org.springframework.experimental</groupId>
-			<artifactId>spring-modulith-api</artifactId>
+			<artifactId>spring-modulith-starter</artifactId>
 			<version>0.1.0-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.experimental</groupId>
-			<artifactId>spring-modulith-moments</artifactId>
-			<version>0.1.0-SNAPSHOT</version>
-		</dependency>
-
-		<!-- Events -->
-
-		<dependency>
-			<groupId>org.springframework.experimental</groupId>
-			<artifactId>spring-modulith-events-core</artifactId>
-			<version>0.1.0-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.experimental</groupId>
-			<artifactId>spring-modulith-events-jackson</artifactId>
-			<version>0.1.0-SNAPSHOT</version>
-			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.experimental</groupId>

--- a/spring-modulith-starter/pom.xml
+++ b/spring-modulith-starter/pom.xml
@@ -8,23 +8,36 @@
 		<version>0.1.0-SNAPSHOT</version>
 	</parent>
 
-	<artifactId>spring-modulith-starter-jpa</artifactId>
-	<name>Spring Modulith - Starter JPA</name>
+	<artifactId>spring-modulith-starter</artifactId>
+	<name>Spring Modulith - Starter Core</name>
 
 	<properties>
-		<module.name>org.springframework.modulith.starter.jpa</module.name>
+		<module.name>org.springframework.modulith.starter</module.name>
 	</properties>
 
 	<dependencies>
 
 		<dependency>
 			<groupId>org.springframework.experimental</groupId>
-			<artifactId>spring-modulith-starter</artifactId>
+			<artifactId>spring-modulith-api</artifactId>
 			<version>0.1.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.experimental</groupId>
-			<artifactId>spring-modulith-events-jpa</artifactId>
+			<artifactId>spring-modulith-moments</artifactId>
+			<version>0.1.0-SNAPSHOT</version>
+		</dependency>
+
+		<!-- Events -->
+
+		<dependency>
+			<groupId>org.springframework.experimental</groupId>
+			<artifactId>spring-modulith-events-core</artifactId>
+			<version>0.1.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.experimental</groupId>
+			<artifactId>spring-modulith-events-jackson</artifactId>
 			<version>0.1.0-SNAPSHOT</version>
 			<scope>runtime</scope>
 		</dependency>


### PR DESCRIPTION
This commit introduces core starter, analogous to [`spring-boot-starter`](https://github.com/spring-projects/spring-boot/tree/main/spring-boot-project/spring-boot-starters/spring-boot-starter), that provides core dependencies without pulling any persistence implementation.

Such starter is useful both for users that intend to implement their own event persistence and as a baseline for other starters to build upon.