### PR TITLE
Fix smaller typos in documentation

### DIFF
--- a/src/docs/asciidoc/30-testing.adoc
+++ b/src/docs/asciidoc/30-testing.adoc
@@ -16,7 +16,7 @@ class OrderIntegrationTests {
 }
 ----
 
-This will run you integration test similar to what `@SpringBootTest` would have achieved but with the bootstrap actually limited to the application module the test resides in.
+This will run your integration test similar to what `@SpringBootTest` would have achieved but with the bootstrap actually limited to the application module the test resides in.
 If you configure the log level for `org.springframework.modulith` to `DEBUG`, you will see detailed information about how the test execution customizes the Spring Boot bootstrap:
 
 .The log output of a application module integration test bootstrap

--- a/src/docs/asciidoc/40-events.adoc
+++ b/src/docs/asciidoc/40-events.adoc
@@ -53,7 +53,7 @@ public class OrderManagement {
 ----
 
 Note, how, instead of depending on the other application module's Spring bean, we use Spring's `ApplicationEventPublisher` to publish a domain event, once we have completed the state transitions on the primary aggregate.
-For a more aggregate-driven approach to even publication, see https://docs.spring.io/spring-data/data-commons/docs/current/reference/html/#core.domain-events[Spring Data's application event publication mechanism] for details.
+For a more aggregate-driven approach to event publication, see https://docs.spring.io/spring-data/data-commons/docs/current/reference/html/#core.domain-events[Spring Data's application event publication mechanism] for details.
 As event publication happens synchronously by default, the transactional semantics of the overall arrangement stay the same as in the example above.
 Both for the good, as we get to a very simple consistency model (either both the status change of the order _and_ the inventory update succeed or none of them does), but also for the bad as more triggered related functionality will widen the transaction boundary and potentially cause the entire transaction to fail, even if the functionality that is causing the error is not crucial.
 

--- a/src/docs/asciidoc/70-observability.adoc
+++ b/src/docs/asciidoc/70-observability.adoc
@@ -9,10 +9,10 @@ To activate the instrumentation add the following runtime dependency to your pro
 ----
 <dependency>
   <groupId>org.springframework.modulith</groupId>
-  <artifactId>spring-modulith</artifactId>
+  <artifactId>spring-modulith-observability</artifactId>
   <version>{projectVersion}</version>
   <scope>runtime</scope
-</dependency
+</dependency>
 ----
 
 This will cause all Spring components that are part of the application module's API being decorated with an aspect that will intercept invocations and create Micrometer spans for them.


### PR DESCRIPTION
This commit fixes a few small typos and an error in a pom snippet.

Greetings from cologne!
Jochen