### PR TITLE
Fix ApplicationModuleDetectionStrategy's package name in reference documentation

### DIFF
--- a/src/docs/asciidoc/10-fundamentals.adoc
+++ b/src/docs/asciidoc/10-fundamentals.adoc
@@ -202,6 +202,6 @@ This class needs to be registered in `META-INF/spring.factories` as follows:
 
 [source, text]
 ----
-org.springframework.modulith.model.ApplicationModuleDetectionStrategy=\
+org.springframework.modulith.core.ApplicationModuleDetectionStrategy=\
   example.CustomApplicationModuleDetectionStrategy
 ----


### PR DESCRIPTION
Use correct ApplicationModuleDetectionStrategy package name. Reference - https://github.com/spring-projects-experimental/spring-modulith/blob/main/spring-modulith-integration-test/src/test/resources/META-INF/spring.factories