### PR TITLE
Add configuration metadata for spring-modulith-events-jdbc

### DIFF
--- a/spring-modulith-events/spring-modulith-events-jdbc/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/spring-modulith-events/spring-modulith-events-jdbc/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+	"properties": [
+		{
+			"name": "spring.modulith.events.schema-initialization.enabled",
+			"type": "java.lang.boolean",
+			"description": "Whether to initialize the event publication schema.",
+			"defaultValue": "false"
+		}
+	]
+}

--- a/src/docs/asciidoc/40-events.adoc
+++ b/src/docs/asciidoc/40-events.adoc
@@ -129,7 +129,7 @@ To actually write the event publication log, Spring Modulith exposes an `EventPu
 You select the persistence technology to be used by adding the corresponding JAR to your Spring Modulith application.
 We have prepared dedicated <<events.starters, starters>> to ease that task.
 
-The JDBC-based implementation will create a dedicated table for the event publication log, unless a table with a particular name already exists.
+The JDBC-based implementation can create a dedicated table for the event publication log when the respective configuration property is enabled.
 For details, please consult the <<appendix.schemas, schema overview>> in the appendix.
 
 [[events.serialization]]


### PR DESCRIPTION
Also adjusted the documentation a bit, because I was whondering why the schema was actually not initializing. Then started looking if there is a config ...