### PR TITLE
Escalate missing ArchUnit runtime dependency

### DIFF
--- a/spring-modulith-runtime/pom.xml
+++ b/spring-modulith-runtime/pom.xml
@@ -23,6 +23,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.tngtech.archunit</groupId>
+			<artifactId>archunit</artifactId>
+			<version>${archunit.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.jgrapht</groupId>
 			<artifactId>jgrapht-core</artifactId>
 			<version>1.4.0</version>

--- a/spring-modulith-runtime/src/main/java/org/springframework/modulith/runtime/autoconfigure/MissingRuntimeDependencyException.java
+++ b/spring-modulith-runtime/src/main/java/org/springframework/modulith/runtime/autoconfigure/MissingRuntimeDependencyException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.modulith.runtime.autoconfigure;
+
+/**
+ * An Exception carrying information about a missing runtime dependency to be
+ * analyzed by {@link MissingRuntimeDependencyFailureAnalyzer}.
+ *
+ * @author Michael Weirauch
+ */
+class MissingRuntimeDependencyException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	private final String dependencyName;
+
+	public MissingRuntimeDependencyException(String dependencyName) {
+		this.dependencyName = dependencyName;
+	}
+
+	public String getDependencyName() {
+		return dependencyName;
+	}
+}

--- a/spring-modulith-runtime/src/main/java/org/springframework/modulith/runtime/autoconfigure/MissingRuntimeDependencyFailureAnalyzer.java
+++ b/spring-modulith-runtime/src/main/java/org/springframework/modulith/runtime/autoconfigure/MissingRuntimeDependencyFailureAnalyzer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.modulith.runtime.autoconfigure;
+
+import org.springframework.boot.diagnostics.AbstractFailureAnalyzer;
+import org.springframework.boot.diagnostics.FailureAnalysis;
+import org.springframework.boot.diagnostics.FailureAnalyzer;
+
+/**
+ * {@link FailureAnalyzer} for {@link MissingRuntimeDependencyException}.
+ *
+ * @author Michael Weirauch
+ */
+class MissingRuntimeDependencyFailureAnalyzer extends AbstractFailureAnalyzer<MissingRuntimeDependencyException> {
+
+	@Override
+	protected FailureAnalysis analyze(Throwable rootFailure, MissingRuntimeDependencyException cause) {
+		return new FailureAnalysis(
+				String.format("Spring Modulith requires the dependency '%s' to be on the runtime classpath.",
+						cause.getDependencyName()),
+				"Add the missing dependency to the runtime classpath of your project.", cause);
+	}
+}

--- a/spring-modulith-runtime/src/main/java/org/springframework/modulith/runtime/autoconfigure/SpringModulithRuntimeAutoConfiguration.java
+++ b/spring-modulith-runtime/src/main/java/org/springframework/modulith/runtime/autoconfigure/SpringModulithRuntimeAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.context.event.ApplicationStartedEvent;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
@@ -45,9 +46,19 @@ import org.springframework.util.Assert;
  * Bean.
  *
  * @author Oliver Drotbohm
+ * @author Michael Weirauch
  */
 @AutoConfiguration
 class SpringModulithRuntimeAutoConfiguration {
+
+	@AutoConfiguration
+	@ConditionalOnMissingClass("com.tngtech.archunit.core.importer.ClassFileImporter")
+	static class ArchUnitRuntimeDependencyMissingConfiguration {
+
+		ArchUnitRuntimeDependencyMissingConfiguration() {
+			throw new MissingRuntimeDependencyException("archunit");
+		}
+	}
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(SpringModulithRuntimeAutoConfiguration.class);
 	private final AsyncTaskExecutor executor = new SimpleAsyncTaskExecutor();

--- a/spring-modulith-runtime/src/main/resources/META-INF/spring.factories
+++ b/spring-modulith-runtime/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+# Failure analyzers
+org.springframework.boot.diagnostics.FailureAnalyzer=\
+org.springframework.modulith.runtime.autoconfigure.MissingRuntimeDependencyFailureAnalyzer


### PR DESCRIPTION
Encountered during `0.5.0-SNAPSHOT` "testing".

EDIT:
* Was causing CNFE for com.tngtech.archunit.core.importer.ImportOption.
* Perhaps having archunit an explicit dependency in spring-modulith-runtime could help here a bit? (Don't have much time to check ATM.)
